### PR TITLE
Add Prod Service Account Impersonation Configuration

### DIFF
--- a/openshift/manifests/rb-documize-admin-sudoers.yaml
+++ b/openshift/manifests/rb-documize-admin-sudoers.yaml
@@ -1,0 +1,31 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: documize-admin-sudoers
+  namespace: 101ed4-prod
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: caggles@github
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: j-pye@github
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: patricksimonian@github
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: poornima-sivanand@github
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: sbathgate@github
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: shellyxuehan@github
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: yhfreeman@github
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: documize-admin-sudoer

--- a/openshift/manifests/rb-documize-admin.yaml
+++ b/openshift/manifests/rb-documize-admin.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: documize-admin
+  namespace: 101ed4-prod
+subjects:
+  - kind: ServiceAccount
+    name: documize-admin
+    namespace: 101ed4-prod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/openshift/manifests/role-documize-admin-sudoer.yaml
+++ b/openshift/manifests/role-documize-admin-sudoer.yaml
@@ -1,0 +1,15 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: documize-admin-sudoer
+  namespace: 101ed4-prod
+rules:
+  - verbs:
+      - impersonate
+    apiGroups:
+      - user.openshift.io
+      - ''
+    resources:
+      - serviceaccounts
+    resourceNames:
+      - documize-admin

--- a/openshift/manifests/sa-documize-admin.yaml
+++ b/openshift/manifests/sa-documize-admin.yaml
@@ -1,0 +1,5 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: documize-admin
+  namespace: 101ed4-prod


### PR DESCRIPTION
Resolves #7 

This still needs docs but I'll write those tomorrow...or is it later today.

This adds a service account in the prod environment, a rolebinding to give the service account Admin permissions in the prod namespace, a role that only enables impersonations of that specific service account, and a rolebinding to enable specific users to impersonate the service account. 

Ex command:
```bash
oc --as system:serviceaccount:101ed4-prod:documize-admin auth can-i create pods
```